### PR TITLE
Set gitlab url to HTTP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "python_plots"]
 	path = python_plots
 	url = git@gitlab.com:GitPrinz/python_plots.git
+[submodule "python_plots/"]
+	url = https://gitlab.com/GitPrinz/python_plots

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,3 @@
 [submodule "python_plots"]
 	path = python_plots
-	url = git@gitlab.com:GitPrinz/python_plots.git
-[submodule "python_plots/"]
 	url = https://gitlab.com/GitPrinz/python_plots


### PR DESCRIPTION
This fixes binder which cannot handle the SSH-based submodule that is currently in `master`:

<https://mybinder.org/v2/gh/mardatade/Course-Visualization-with-Python/fix-submodule>